### PR TITLE
Added wheelZoomFactor property to OrbitManipulatorQtQml class

### DIFF
--- a/src/qml/osgga/orbitmanipulator.cpp
+++ b/src/qml/osgga/orbitmanipulator.cpp
@@ -50,6 +50,20 @@ void OrbitManipulatorQtQml::classBegin()
     StandardManipulatorQtQml::classBegin();
 }
 
+qreal OrbitManipulatorQtQml::getWheelZoomFactor() const
+{
+    return static_cast<qreal>(static_cast<Index*>(i)->othis->getWheelZoomFactor());
+}
+
+void OrbitManipulatorQtQml::setWheelZoomFactor(qreal wheelZoomFactor)
+{
+    if (getWheelZoomFactor() == wheelZoomFactor) return;
+
+    static_cast<Index*>(i)->othis->setWheelZoomFactor(static_cast<float>(wheelZoomFactor));
+
+    emit wheelZoomFactorChanged(wheelZoomFactor);
+}
+
 OrbitManipulator *OrbitManipulatorQtQml::orbitManipulator()
 {
     return static_cast<Index*>(i)->othis;

--- a/src/qml/osgga/orbitmanipulator.hpp
+++ b/src/qml/osgga/orbitmanipulator.hpp
@@ -11,6 +11,8 @@ class OSGQTQML_EXPORT OrbitManipulatorQtQml : public StandardManipulatorQtQml
 {
   Q_OBJECT
 
+  Q_PROPERTY(qreal wheelZoomFactor READ getWheelZoomFactor WRITE setWheelZoomFactor NOTIFY wheelZoomFactorChanged)
+
 public:
   class Index;
 
@@ -19,9 +21,15 @@ public:
 
   void classBegin();
 
+  qreal getWheelZoomFactor() const;
+  void setWheelZoomFactor(qreal wheelZoomFactor);
+
   OrbitManipulator* orbitManipulator();
 
   static OrbitManipulatorQtQml* fromOrbitManipulator(OrbitManipulator *orbitManipulator, QObject *parent = 0);
+
+signals:
+  void wheelZoomFactorChanged(qreal wheelZoomFactor) const;
 };
 
 }


### PR DESCRIPTION
Default zoom direction for mouse wheel is different from standard 3D application, example Blender. To invert zoom direction, wheelZoomFactor may be sets to -0.1 value.
