### PR TITLE
remove 'lib' prefix in plugin names for mingw compiler

### DIFF
--- a/cmake/osgQtQuickFunctions.cmake
+++ b/cmake/osgQtQuickFunctions.cmake
@@ -26,6 +26,10 @@ function(osgqtquick_imported_module module_name)
   set_property(TARGET ${target_name} PROPERTY
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/imports/${module_name}")
 
+  if(MINGW)
+    set_target_properties(${target_name} PROPERTIES PREFIX "")
+  endif()
+
   target_include_directories(${target_name}
     PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 


### PR DESCRIPTION
On Windows with MinGW compiler plugin names libosgplugin.dll, libosgdbplugin.dll, etc raises error like:

module "osg" plugin "osgplugin" not found

So better remove 'lib' prefix by CMake rule:

  if(MINGW)
    set_target_properties(${target_name} PROPERTIES PREFIX "")
  endif()
