### PR TITLE
Fixed connect with SIGNAL(beforeRendering()) for threaded Render Loops

### DIFF
--- a/src/quick/window.cpp
+++ b/src/quick/window.cpp
@@ -18,7 +18,7 @@ Window::Window(QQuickWindow *window) :
 
     d.window = window;
 
-    connect(window, SIGNAL(beforeRendering()), this, SLOT(frame()));
+    connect(window, SIGNAL(beforeRendering()), this, SLOT(frame()), Qt::DirectConnection);
 
     // Render loop
     d.window->setClearBeforeRendering(false);


### PR DESCRIPTION
From Qt Doc:

The scene graph is rendered:

The QQuickWindow::beforeRendering() signal is emitted. Applications can make direct connections (using Qt::DirectConnection) to this signal to use custom OpenGL calls which will then stack visually beneath the QML scene.

This fix closes issue https://github.com/podsvirov/osgqtquick/issues/4
