### PR TITLE
Fixed frame rate bug with camera manipulator in rotating mode

### DIFF
--- a/src/quick/window.cpp
+++ b/src/quick/window.cpp
@@ -22,7 +22,9 @@ Window::Window(QQuickWindow *window) :
 
     // Render loop
     d.window->setClearBeforeRendering(false);
-    d.frameTimer = startTimer(10);
+    // 17 mc -> 59 fps (< 60 fps)
+    // Any timer value less then 17 mc (> 60 fps) is caused bug with camera manipulator in rotating mode
+    d.frameTimer = startTimer(17);
 
     // Context
     d.context = new osgViewer::GraphicsWindowEmbedded(0, 0,


### PR DESCRIPTION
Changed fps of synchronizing OSG and QSG to value 59 (17 ms). If fps is greater than 60, camera manipulator has nasty behavior in rotating mode.
