### PR TITLE
Build issues on some systems/platforms

### DIFF
--- a/src/debugger/main.cpp
+++ b/src/debugger/main.cpp
@@ -1,9 +1,9 @@
 // Qt headers
-#include <QGuiApplication>
-#include <QQuickView>
+#include <QtGui/QGuiApplication>
+#include <QtQuick/QQuickView>
 
-#include <QQmlContext>
-#include <QDateTime>
+#include <QtQml/QQmlContext>
+#include <QtCore/QDateTime>
 
 // osgQtQuick
 #include <osg/ModuleQtQml>

--- a/src/imports/osg/plugin.cpp
+++ b/src/imports/osg/plugin.cpp
@@ -1,4 +1,4 @@
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include <osg/ModuleQtQml>
 

--- a/src/imports/osgdb/plugin.cpp
+++ b/src/imports/osgdb/plugin.cpp
@@ -1,4 +1,4 @@
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include <osgDB/ModuleQtQml>
 

--- a/src/imports/osgearthutil/plugin.cpp
+++ b/src/imports/osgearthutil/plugin.cpp
@@ -1,4 +1,4 @@
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include <osgEarthUtil/ModuleQtQml>
 

--- a/src/imports/osgga/plugin.cpp
+++ b/src/imports/osgga/plugin.cpp
@@ -1,4 +1,4 @@
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include <osgGA/ModuleQtQml>
 

--- a/src/imports/osgmanipulator/plugin.cpp
+++ b/src/imports/osgmanipulator/plugin.cpp
@@ -1,4 +1,4 @@
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include <osgManipulator/ModuleQtQml>
 

--- a/src/imports/osgtext/plugin.cpp
+++ b/src/imports/osgtext/plugin.cpp
@@ -1,4 +1,4 @@
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include <osgText/ModuleQtQml>
 

--- a/src/imports/osgviewer/plugin.cpp
+++ b/src/imports/osgviewer/plugin.cpp
@@ -1,4 +1,4 @@
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include <osgViewer/ModuleQtQml>
 #include <osgViewer/ModuleQtQuick>

--- a/src/qml/CMakeLists.txt
+++ b/src/qml/CMakeLists.txt
@@ -11,6 +11,7 @@ set(_moc_hdrs)
 macro(META_Node _library _class)
   string(TOLOWER ${_library} _library_l)
   string(TOLOWER ${_class} _class_l)
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include/${_library}")
   file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/include/${_library}/${_class}QtQml"
     CONTENT "#include \"${CMAKE_CURRENT_LIST_DIR}/${_library_l}/${_class_l}.hpp\"\n")
   install(FILES "${CMAKE_CURRENT_LIST_DIR}/${_library_l}/${_class_l}.hpp"
@@ -156,6 +157,8 @@ target_link_libraries(osgQtQml
   ${OSGEARTHUTIL_LIBRARY}
   Qt5::Gui
   Qt5::Qml)
+
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include/osgQtQml")
 
 file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/include/osgQtQml/Export"
   CONTENT "#include \"${CMAKE_CURRENT_LIST_DIR}/export.hpp\"\n")

--- a/src/qml/index.cpp
+++ b/src/qml/index.cpp
@@ -1,6 +1,6 @@
 #include "index.hpp"
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgQtQml {
 

--- a/src/qml/index.hpp
+++ b/src/qml/index.hpp
@@ -11,12 +11,12 @@
 #include <osg/Quat>
 #include <osgText/String>
 
-#include <QObject>
-#include <QPointer>
-#include <QColor>
-#include <QVector3D>
-#include <QMatrix4x4>
-#include <QQuaternion>
+#include <QtCore/QObject>
+#include <QtCore/QPointer>
+#include <QtGui/QColor>
+#include <QtGui/QVector3D>
+#include <QtGui/QMatrix4x4>
+#include <QtGui/QQuaternion>
 
 #include <list>
 #include <set>

--- a/src/qml/object.cpp
+++ b/src/qml/object.cpp
@@ -1,7 +1,7 @@
 #include "object.hpp"
 #include "index.hpp"
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 osgQtQml::Object::Object(QObject *parent) :
   QObject(parent), _i_ptr(0),

--- a/src/qml/object.hpp
+++ b/src/qml/object.hpp
@@ -2,7 +2,7 @@
 #define _OSGQTQML_OBJECT_ 1
 
 #include <osgQtQml/Export>
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 
 namespace osgQtQml {
 

--- a/src/qml/osg/box.cpp
+++ b/src/qml/osg/box.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/Shape>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Box

--- a/src/qml/osg/box.hpp
+++ b/src/qml/osg/box.hpp
@@ -2,8 +2,8 @@
 #define _OSG_BOX_QTQML_ 1
 
 #include <osg/ShapeQtQml>
-#include <QVector3D>
-#include <QQuaternion>
+#include <QtGui/QVector3D>
+#include <QtGui/QQuaternion>
 
 namespace osg {
 
@@ -38,7 +38,7 @@ public:
 
   static BoxQtQml* fromBox(Box *box, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void centerChanged(const QVector3D &center) const;
   void halfLengthsChanged(const QVector3D &halfLengths) const;
   void rotationChanged(const QQuaternion &quat) const;

--- a/src/qml/osg/camera.cpp
+++ b/src/qml/osg/camera.cpp
@@ -3,7 +3,7 @@
 
 #include <osg/Camera>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Camera

--- a/src/qml/osg/camera.hpp
+++ b/src/qml/osg/camera.hpp
@@ -3,7 +3,7 @@
 
 #include <osg/TransformQtQml>
 
-#include <QColor>
+#include <QtGui/QColor>
 
 namespace osg {
 
@@ -34,7 +34,7 @@ public:
 
   static CameraQtQml* fromCamera(Camera *camera, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void clearColorChanged(const QColor &color) const;
   void nearFarRatioChanged(const double ratio) const;
 };

--- a/src/qml/osg/compositeshape.cpp
+++ b/src/qml/osg/compositeshape.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/Shape>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype CompositeShape

--- a/src/qml/osg/compositeshape.hpp
+++ b/src/qml/osg/compositeshape.hpp
@@ -3,7 +3,7 @@
 
 #include <osg/ShapeQtQml>
 
-#include <QQmlListProperty>
+#include <QtQml/QQmlListProperty>
 
 namespace osg {
 
@@ -43,7 +43,7 @@ public:
 
   static CompositeShapeQtQml* fromCompositeShape(CompositeShape *compositeShape, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void shapeChanged(ShapeQtQml *shape) const;
   void numChildrenChanged(int num);
 

--- a/src/qml/osg/cylinder.cpp
+++ b/src/qml/osg/cylinder.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/Shape>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Cylinder

--- a/src/qml/osg/cylinder.hpp
+++ b/src/qml/osg/cylinder.hpp
@@ -2,7 +2,7 @@
 #define _OSG_CYLINDER_QTQML_ 1
 
 #include <osg/ShapeQtQml>
-#include <QVector3D>
+#include <QtGui/QVector3D>
 
 namespace osg {
 
@@ -37,7 +37,7 @@ public:
 
   static CylinderQtQml* fromCylinder(Cylinder *cylinder, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void centerChanged(const QVector3D &center) const;
   void radiusChanged(float radius);
   void heightChanged(float height);

--- a/src/qml/osg/geode.cpp
+++ b/src/qml/osg/geode.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/Geode>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Geode

--- a/src/qml/osg/geode.hpp
+++ b/src/qml/osg/geode.hpp
@@ -4,7 +4,7 @@
 #include <osg/GroupQtQml>
 #include <osg/DrawableQtQml>
 
-#include <QQmlListProperty>
+#include <QtQml/QQmlListProperty>
 
 namespace osg {
 
@@ -40,7 +40,7 @@ public:
 
   static GeodeQtQml* fromGeode(Geode *geode, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void numDrawablesChanged(int num);
 
 protected:

--- a/src/qml/osg/group.cpp
+++ b/src/qml/osg/group.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/Group>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Group

--- a/src/qml/osg/group.hpp
+++ b/src/qml/osg/group.hpp
@@ -3,7 +3,7 @@
 
 #include <osg/NodeQtQml>
 
-#include <QQmlListProperty>
+#include <QtQml/QQmlListProperty>
 
 namespace osg {
 
@@ -40,7 +40,7 @@ public:
 
   static GroupQtQml* fromGroup(Group *group, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void numChildrenChanged(int num);
 
 protected:

--- a/src/qml/osg/matrixtransform.cpp
+++ b/src/qml/osg/matrixtransform.cpp
@@ -3,7 +3,7 @@
 
 #include <osg/MatrixTransform>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype MatrixTransform

--- a/src/qml/osg/matrixtransform.hpp
+++ b/src/qml/osg/matrixtransform.hpp
@@ -3,7 +3,7 @@
 
 #include <osg/TransformQtQml>
 
-#include <QMatrix4x4>
+#include <QtGui/QMatrix4x4>
 
 namespace osg {
 
@@ -30,7 +30,7 @@ public:
 
   static MatrixTransformQtQml* fromMatrixTransform(MatrixTransform *transform, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void matrixChanged(const QMatrix4x4 &mat) const;
 };
 

--- a/src/qml/osg/module.cpp
+++ b/src/qml/osg/module.cpp
@@ -24,9 +24,9 @@
 #include <osgQtQml/Object>
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osg {
 

--- a/src/qml/osg/notify.cpp
+++ b/src/qml/osg/notify.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/Notify>
 
-#include <QLoggingCategory>
+#include <QtCore/QLoggingCategory>
 
 namespace osg {
 

--- a/src/qml/osg/notify.hpp
+++ b/src/qml/osg/notify.hpp
@@ -38,7 +38,7 @@ public:
   Q_INVOKABLE NotifyLevel getNotifyLevel() const;
   Q_INVOKABLE void setNotifyLevel(const NotifyLevel level);
 
-signals:
+Q_SIGNALS:
   void notifyLevelChanged(const NotifyLevel level) const;
 
   void notify(const QString& message) const;

--- a/src/qml/osg/object.hpp
+++ b/src/qml/osg/object.hpp
@@ -28,7 +28,7 @@ public:
 
   static ObjectQtQml* fromObject(osg::Object *object, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void nameChanged(QString name) const;
 };
 

--- a/src/qml/osg/positionattitudetransform.cpp
+++ b/src/qml/osg/positionattitudetransform.cpp
@@ -3,7 +3,7 @@
 
 #include <osg/PositionAttitudeTransform>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype PositionAttitudeTransform

--- a/src/qml/osg/positionattitudetransform.hpp
+++ b/src/qml/osg/positionattitudetransform.hpp
@@ -3,8 +3,8 @@
 
 #include <osg/TransformQtQml>
 
-#include <QVector3D>
-#include <QQuaternion>
+#include <QtGui/QVector3D>
+#include <QtGui/QQuaternion>
 
 namespace osg {
 
@@ -43,7 +43,7 @@ public:
 
   static PositionAttitudeTransformQtQml* fromPositionAttitudeTransform(PositionAttitudeTransform *transform, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void positionChanged(const QVector3D &pos) const;
   void attitudeChanged(const QQuaternion &quat) const;
   void scaleChanged(const QVector3D &scale) const;

--- a/src/qml/osg/shapedrawable.cpp
+++ b/src/qml/osg/shapedrawable.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/ShapeDrawable>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype ShapeDrawable

--- a/src/qml/osg/shapedrawable.hpp
+++ b/src/qml/osg/shapedrawable.hpp
@@ -5,7 +5,7 @@
 
 #include <osg/ShapeQtQml>
 
-#include <QColor>
+#include <QtGui/QColor>
 
 namespace osg {
 
@@ -36,7 +36,7 @@ public:
 
   static ShapeDrawableQtQml* fromShapeDrawable(ShapeDrawable *drawable, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void shapeChanged(ShapeQtQml *shape) const;
   void colorChanged(const QColor &color) const;
 };

--- a/src/qml/osg/sphere.cpp
+++ b/src/qml/osg/sphere.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/Shape>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Sphere

--- a/src/qml/osg/sphere.hpp
+++ b/src/qml/osg/sphere.hpp
@@ -2,7 +2,7 @@
 #define _OSG_SPHERE_QTQML_ 1
 
 #include <osg/ShapeQtQml>
-#include <QVector3D>
+#include <QtGui/QVector3D>
 
 namespace osg {
 
@@ -33,7 +33,7 @@ public:
 
   static SphereQtQml* fromSphere(Sphere *sphere, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void centerChanged(const QVector3D &center) const;
   void radiusChanged(float arg);
 };

--- a/src/qml/osg/transform.cpp
+++ b/src/qml/osg/transform.cpp
@@ -5,7 +5,7 @@
 
 #include <osg/Transform>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Transform

--- a/src/qml/osgdb/loader.cpp
+++ b/src/qml/osgdb/loader.cpp
@@ -5,7 +5,7 @@
 
 #include <osgDB/ReadFile>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Loader

--- a/src/qml/osgdb/loader.hpp
+++ b/src/qml/osgdb/loader.hpp
@@ -2,7 +2,7 @@
 #define _OSGDB_LOADER_QTQML_ 1
 
 #include <osg/GroupQtQml>
-#include <QUrl>
+#include <QtCore/QUrl>
 
 namespace osgDB {
 
@@ -42,12 +42,12 @@ public:
 
   static LoaderQtQml* fromGroup(osg::Group *group, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void nodeChanged(osg::NodeQtQml* node);
   void sourceChanged(const QUrl &source);
   void statusChanged(Status status);
 
-private slots:
+private Q_SLOTS:
   void nodeLoadingDone(const QUrl &url, osg::Node* node);
 };
 

--- a/src/qml/osgdb/loaderindex.hpp
+++ b/src/qml/osgdb/loaderindex.hpp
@@ -8,13 +8,13 @@
 #include <osgDB/ReadFile>
 #include <osgDB/FileUtils>
 
-#include <QThread>
+#include <QtCore/QThread>
 
-#include <QDebug>
-#include <QFileInfo>
+#include <QtCore/QDebug>
+#include <QtCore/QFileInfo>
 
 #include <cstdlib>
-#include <QDir>
+#include <QtCore/QDir>
 
 namespace osgDB {
 
@@ -78,7 +78,7 @@ public:
         emit loaded(url, node.get());
     }
 
-signals:
+Q_SIGNALS:
     void loaded(const QUrl& url, osg::Node *node);
 
 private:

--- a/src/qml/osgdb/module.cpp
+++ b/src/qml/osgdb/module.cpp
@@ -3,9 +3,9 @@
 #include "loaderindex.hpp"
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgDB {
 

--- a/src/qml/osgearthutil/earthmanipulator.cpp
+++ b/src/qml/osgearthutil/earthmanipulator.cpp
@@ -5,7 +5,7 @@
 
 #include <osgEarthUtil/EarthManipulator>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgEarth { namespace Util {
 

--- a/src/qml/osgearthutil/module.cpp
+++ b/src/qml/osgearthutil/module.cpp
@@ -3,9 +3,9 @@
 #include "earthmanipulatorindex.hpp"
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgEarth { namespace Util {
 

--- a/src/qml/osgga/cameramanipulator.cpp
+++ b/src/qml/osgga/cameramanipulator.cpp
@@ -3,7 +3,7 @@
 
 #include <osgQtQml/Index>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype CameraManipulator

--- a/src/qml/osgga/cameramanipulator.hpp
+++ b/src/qml/osgga/cameramanipulator.hpp
@@ -3,7 +3,7 @@
 
 #include <osg/ObjectQtQml>
 
-#include <QVector3D>
+#include <QtGui/QVector3D>
 
 namespace osgGA {
 

--- a/src/qml/osgga/firstpersonmanipulator.cpp
+++ b/src/qml/osgga/firstpersonmanipulator.cpp
@@ -5,7 +5,7 @@
 
 #include <osgGA/FirstPersonManipulator>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype FirstPersonManipulator

--- a/src/qml/osgga/flightmanipulator.cpp
+++ b/src/qml/osgga/flightmanipulator.cpp
@@ -5,7 +5,7 @@
 
 #include <osgGA/FlightManipulator>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype FlightManipulator

--- a/src/qml/osgga/module.cpp
+++ b/src/qml/osgga/module.cpp
@@ -9,9 +9,9 @@
 #include "nodetrackermanipulatorindex.hpp"
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgGA {
 

--- a/src/qml/osgga/nodetrackermanipulator.cpp
+++ b/src/qml/osgga/nodetrackermanipulator.cpp
@@ -5,7 +5,7 @@
 
 #include <osgGA/NodeTrackerManipulator>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype NodeTrackerManipulator

--- a/src/qml/osgga/nodetrackermanipulator.hpp
+++ b/src/qml/osgga/nodetrackermanipulator.hpp
@@ -52,7 +52,7 @@ public:
 
   static NodeTrackerManipulatorQtQml* fromNodeTrackerManipulator(NodeTrackerManipulator *manipulator, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void trackNodeChanged(osg::NodeQtQml *node);
   void trackerModeChanged(TrackerMode mode);
   void rotationModeChanged(RotationMode mode);

--- a/src/qml/osgga/orbitmanipulator.cpp
+++ b/src/qml/osgga/orbitmanipulator.cpp
@@ -5,7 +5,7 @@
 
 #include <osgGA/OrbitManipulator>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype OrbitManipulator

--- a/src/qml/osgga/orbitmanipulator.hpp
+++ b/src/qml/osgga/orbitmanipulator.hpp
@@ -28,7 +28,7 @@ public:
 
   static OrbitManipulatorQtQml* fromOrbitManipulator(OrbitManipulator *orbitManipulator, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void wheelZoomFactorChanged(qreal wheelZoomFactor) const;
 };
 

--- a/src/qml/osgga/standardmanipulator.cpp
+++ b/src/qml/osgga/standardmanipulator.cpp
@@ -5,7 +5,7 @@
 
 #include <osgGA/StandardManipulator>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype StandardManipulator

--- a/src/qml/osgga/standardmanipulator.hpp
+++ b/src/qml/osgga/standardmanipulator.hpp
@@ -30,7 +30,7 @@ public:
 
   static StandardManipulatorQtQml* fromStandardManipulator(StandardManipulator *manipulator, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void nodeChanged(osg::NodeQtQml *node);
 };
 

--- a/src/qml/osgga/trackballmanipulator.cpp
+++ b/src/qml/osgga/trackballmanipulator.cpp
@@ -5,7 +5,7 @@
 
 #include <osgGA/TrackballManipulator>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype TrackballManipulator

--- a/src/qml/osgmanipulator/compositedragger.cpp
+++ b/src/qml/osgmanipulator/compositedragger.cpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/Dragger>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 // TODO: Add CompositeDragger type as base fo TabBoxDragger
 

--- a/src/qml/osgmanipulator/compositedragger.hpp
+++ b/src/qml/osgmanipulator/compositedragger.hpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/DraggerQtQml>
 
-#include <QColor>
+#include <QtGui/QColor>
 
 namespace osgManipulator {
 
@@ -37,7 +37,7 @@ public:
 
   static CompositeDraggerQtQml* fromCompositeDragger(CompositeDragger *dragger, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void numDraggersChanged(int num);
 
 protected:

--- a/src/qml/osgmanipulator/dragger.cpp
+++ b/src/qml/osgmanipulator/dragger.cpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/Dragger>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Dragger

--- a/src/qml/osgmanipulator/dragger.hpp
+++ b/src/qml/osgmanipulator/dragger.hpp
@@ -3,7 +3,7 @@
 
 #include <osg/MatrixTransformQtQml>
 
-#include <QMatrix4x4>
+#include <QtGui/QMatrix4x4>
 
 namespace osgManipulator {
 
@@ -41,7 +41,7 @@ public:
 
   static DraggerQtQml* fromDragger(Dragger *dragger, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void handleEventsChanged(bool handleEvents) const;
   void draggerActiveChanged(bool draggerActive) const;
 };

--- a/src/qml/osgmanipulator/module.cpp
+++ b/src/qml/osgmanipulator/module.cpp
@@ -7,9 +7,9 @@
 #include "tabboxdraggerindex.hpp"
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgManipulator {
 

--- a/src/qml/osgmanipulator/rotatespheredragger.cpp
+++ b/src/qml/osgmanipulator/rotatespheredragger.cpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/RotateSphereDragger>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype RotateSphereDragger

--- a/src/qml/osgmanipulator/rotatespheredragger.hpp
+++ b/src/qml/osgmanipulator/rotatespheredragger.hpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/DraggerQtQml>
 
-#include <QColor>
+#include <QtGui/QColor>
 
 namespace osgManipulator {
 
@@ -34,7 +34,7 @@ public:
 
   static RotateSphereDraggerQtQml* fromRotateSphereDragger(RotateSphereDragger *dragger, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void colorChanged(const QColor &color) const;
   void pickColorChanged(const QColor &color) const;
 };

--- a/src/qml/osgmanipulator/tabboxdragger.cpp
+++ b/src/qml/osgmanipulator/tabboxdragger.cpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/TabBoxDragger>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 // TODO: Add CompositeDragger type as base fo TabBoxDragger
 

--- a/src/qml/osgmanipulator/tabboxdragger.hpp
+++ b/src/qml/osgmanipulator/tabboxdragger.hpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/CompositeDraggerQtQml>
 
-#include <QColor>
+#include <QtGui/QColor>
 
 namespace osgManipulator {
 
@@ -30,7 +30,7 @@ public:
 
   static TabBoxDraggerQtQml* fromTabBoxDragger(TabBoxDragger *dragger, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void planeColorChanged(const QColor &color) const;
 };
 

--- a/src/qml/osgmanipulator/tabplanedragger.cpp
+++ b/src/qml/osgmanipulator/tabplanedragger.cpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/TabPlaneDragger>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 // TODO: Add CompositeDragger type as base fo TabPlaneDragger
 

--- a/src/qml/osgmanipulator/tabplanedragger.hpp
+++ b/src/qml/osgmanipulator/tabplanedragger.hpp
@@ -3,7 +3,7 @@
 
 #include <osgManipulator/CompositeDraggerQtQml>
 
-#include <QColor>
+#include <QtGui/QColor>
 
 namespace osgManipulator {
 
@@ -30,7 +30,7 @@ public:
 
   static TabPlaneDraggerQtQml* fromTabPlaneDragger(TabPlaneDragger *dragger, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void planeColorChanged(const QColor &color) const;
 };
 

--- a/src/qml/osgqt/module.cpp
+++ b/src/qml/osgqt/module.cpp
@@ -3,9 +3,9 @@
 #include "qfontimplementationindex.hpp"
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgQt {
 

--- a/src/qml/osgqt/qfontimplementation.cpp
+++ b/src/qml/osgqt/qfontimplementation.cpp
@@ -5,7 +5,7 @@
 
 #include <osgText/Font>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype QFontImplementation

--- a/src/qml/osgqt/qfontimplementation.hpp
+++ b/src/qml/osgqt/qfontimplementation.hpp
@@ -3,7 +3,7 @@
 
 #include <osgText/FontImplementationQtQml>
 
-#include <QFont>
+#include <QtGui/QFont>
 
 namespace osgQt {
 
@@ -30,7 +30,7 @@ public:
 
   static QFontImplementationQtQml* fromQFontImplementation(QFontImplementation *implementation, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void fontChanged(const QFont &font) const;
 };
 

--- a/src/qml/osgtext/font.cpp
+++ b/src/qml/osgtext/font.cpp
@@ -5,7 +5,7 @@
 
 #include <osgText/Font>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Font

--- a/src/qml/osgtext/font.hpp
+++ b/src/qml/osgtext/font.hpp
@@ -34,7 +34,7 @@ public:
 
   static FontQtQml* fromFont(Font *font, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void implementationChanged(FontImplementationQtQml *implementation) const;
   void glyphImageMarginRatioChanged(qreal widthRatio) const;
 };

--- a/src/qml/osgtext/fontimplementation.cpp
+++ b/src/qml/osgtext/fontimplementation.cpp
@@ -5,7 +5,7 @@
 
 #include <osgText/Font>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype FontImplementation

--- a/src/qml/osgtext/module.cpp
+++ b/src/qml/osgtext/module.cpp
@@ -7,9 +7,9 @@
 #include "text3dindex.hpp"
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgText {
 

--- a/src/qml/osgtext/style.cpp
+++ b/src/qml/osgtext/style.cpp
@@ -5,7 +5,7 @@
 
 #include <osgText/Style>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Style

--- a/src/qml/osgtext/style.hpp
+++ b/src/qml/osgtext/style.hpp
@@ -5,7 +5,7 @@
 
 #include <osg/ShapeQtQml>
 
-#include <QColor>
+#include <QtGui/QColor>
 
 namespace osgText {
 
@@ -37,7 +37,7 @@ public:
 
   static StyleQtQml* fromStyle(Style *style, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   //void shapeChanged(ShapeQtQml *shape) const;
   void widthRatioChanged(qreal widthRatio) const;
 };

--- a/src/qml/osgtext/text3d.cpp
+++ b/src/qml/osgtext/text3d.cpp
@@ -5,7 +5,7 @@
 
 #include <osgQt/QFontImplementation>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype Text3D

--- a/src/qml/osgtext/text3d.hpp
+++ b/src/qml/osgtext/text3d.hpp
@@ -3,7 +3,7 @@
 
 #include <osgText/TextBaseQtQml>
 
-#include <QColor>
+#include <QtGui/QColor>
 
 namespace osgText {
 
@@ -30,7 +30,7 @@ public:
 
   static Text3DQtQml* fromText3D(Text3D *text3D, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void characterDepthChanged(qreal depth) const;
 };
 

--- a/src/qml/osgtext/textbase.cpp
+++ b/src/qml/osgtext/textbase.cpp
@@ -8,11 +8,11 @@
 #include <osgDB/ReadFile>
 #include <osgDB/FileUtils>
 
-#include <QFileInfo>
-#include <QQmlContext>
-#include <QQmlEngine>
+#include <QtCore/QFileInfo>
+#include <QtQml/QQmlContext>
+#include <QtQml/QQmlEngine>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 /*!
    \qmltype TextBase

--- a/src/qml/osgtext/textbase.hpp
+++ b/src/qml/osgtext/textbase.hpp
@@ -6,8 +6,8 @@
 #include <osgText/StyleQtQml>
 #include <osgText/FontQtQml>
 
-#include <QColor>
-#include <QUrl>
+#include <QtGui/QColor>
+#include <QtCore/QUrl>
 
 namespace osgText {
 
@@ -89,7 +89,7 @@ public:
 
   static TextBaseQtQml* fromTextBase(TextBase *textBase, QObject *parent = 0);
 
-signals:
+Q_SIGNALS:
   void styleChanged(StyleQtQml *shape) const;
   void fontChanged(FontQtQml *font) const;
   void fontSourceChanged(const QUrl &source);

--- a/src/qml/osgviewer/module.cpp
+++ b/src/qml/osgviewer/module.cpp
@@ -3,7 +3,7 @@
 #include "compositeviewerindex.hpp"
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
 namespace osgViewer {
 

--- a/src/quick/CMakeLists.txt
+++ b/src/quick/CMakeLists.txt
@@ -15,6 +15,7 @@ set(_moc_hdrs)
 macro(META_Node _library _class)
   string(TOLOWER ${_library} _library_l)
   string(TOLOWER ${_class} _class_l)
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include/${_library}")
   file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/include/${_library}/${_class}QtQuick"
     CONTENT "#include \"${CMAKE_CURRENT_LIST_DIR}/${_library_l}/${_class_l}.hpp\"\n")
   install(FILES "${CMAKE_CURRENT_LIST_DIR}/${_library_l}/${_class_l}.hpp"

--- a/src/quick/index.hpp
+++ b/src/quick/index.hpp
@@ -7,9 +7,9 @@
 
 #include <osg/View>
 
-#include <QQuickItem>
-#include <QQuickWindow>
-#include <QKeyEvent>
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtGui/QKeyEvent>
 
 #include <map>
 

--- a/src/quick/object.cpp
+++ b/src/quick/object.cpp
@@ -3,7 +3,7 @@
 
 #include <osgQtQml/Index>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgQtQuick {
 

--- a/src/quick/object.hpp
+++ b/src/quick/object.hpp
@@ -2,7 +2,7 @@
 #define _OSGQTQUICK_OBJECT_ 1
 
 #include <osgQtQuick/Export>
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 
 namespace osgQtQuick {
 

--- a/src/quick/osgviewer/module.cpp
+++ b/src/quick/osgviewer/module.cpp
@@ -7,9 +7,9 @@
 #include <osgQtQuick/Object>
 
 #include <osgQtQuick/Version>
-#include <QtQml>
+#include <QtQml/QtQml>
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 namespace osgViewer {
 

--- a/src/quick/osgviewer/view.cpp
+++ b/src/quick/osgviewer/view.cpp
@@ -10,8 +10,8 @@
 #include <osgViewer/ViewerEventHandlers>
 #include <osgGA/TrackballManipulator>
 
-#include <QMouseEvent>
-#include <QKeyEvent>
+#include <QtGui/QMouseEvent>
+#include <QtGui/QKeyEvent>
 
 /*!
    \qmltype View

--- a/src/quick/osgviewer/view.hpp
+++ b/src/quick/osgviewer/view.hpp
@@ -37,7 +37,7 @@ public:
 
   static ViewQtQuick* fromView(View *view, QQuickItem *parent = 0);
 
-signals:
+Q_SIGNALS:
   void sceneDataChanged(osg::NodeQtQml *node);
   void cameraChanged(osg::CameraQtQml *camera);
   void cameraManipulatorChanged(osgGA::CameraManipulatorQtQml *manipulator);

--- a/src/quick/osgviewer/viewindex.hpp
+++ b/src/quick/osgviewer/viewindex.hpp
@@ -7,9 +7,9 @@
 #include <osg/Camera>
 #include <osgViewer/ViewQtQuick>
 
-#include <QOpenGLFramebufferObject>
-#include <QSGSimpleTextureNode>
-#include <QMutex>
+#include <QtGui/QOpenGLFramebufferObject>
+#include <QtQuick/QSGSimpleTextureNode>
+#include <QtCore/QMutex>
 
 namespace osgQtQuick {
 class Window;

--- a/src/quick/renderthread.hpp
+++ b/src/quick/renderthread.hpp
@@ -5,12 +5,12 @@
 #include <osgViewer/ViewQtQuick>
 
 #include <QGuiApplication>
-#include <QThread>
-#include <QOpenGLContext>
-#include <QOpenGLFunctions>
-#include <QOffscreenSurface>
-#include <QOpenGLFramebufferObjectFormat>
-#include <QDateTime>
+#include <QtCore/QThread>
+#include <QtGui/QOpenGLContext>
+#include <QtGui/QOpenGLFunctions>
+#include <QtGui/QOffscreenSurface>
+#include <QtGui/QOpenGLFramebufferObjectFormat>
+#include <QtCore/QDateTime>
 
 namespace osgQtQuick {
 
@@ -29,14 +29,14 @@ public:
     QOffscreenSurface *surface;
     QOpenGLContext *context;
 
-public slots:
+public Q_SLOTS:
     void renderNext();
 
     void shutDown();
 
     void acceptNewSize(osgViewer::ViewQtQuick::Index *view, QSize size);
 
-signals:
+Q_SIGNALS:
     void textureReady();
 
 private:

--- a/src/quick/window.cpp
+++ b/src/quick/window.cpp
@@ -59,7 +59,7 @@ Window::Window(QQuickWindow *window) :
             renderLoopType = WindowsRenderLoop;
 #else
         if (QGuiApplicationPrivate::platformIntegration()->hasCapability(QPlatformIntegration::ThreadedOpenGL))
-            loopType = ThreadedRenderLoop;
+            renderLoopType = ThreadedRenderLoop;
 #endif
         if (qmlNoThreadedRenderer())
             renderLoopType = BasicRenderLoop;

--- a/src/quick/window.cpp
+++ b/src/quick/window.cpp
@@ -6,9 +6,9 @@
 #include <osgViewer/CompositeViewerQtQml>
 #include <osgViewer/ViewQtQuickIndex>
 
-#include <QOpenGLContext>
-#include <QOpenGLFunctions>
-#include <QTimerEvent>
+#include <QtGui/QOpenGLContext>
+#include <QtGui/QOpenGLFunctions>
+#include <QtCore/QTimerEvent>
 
 #ifdef OSGQTQUICK_WITH_QT_PRIVATE
 

--- a/src/quick/window.hpp
+++ b/src/quick/window.hpp
@@ -3,7 +3,7 @@
 
 #include <osgQtQuick/Export>
 
-#include <QQuickWindow>
+#include <QtQuick/QQuickWindow>
 
 #include <osgViewer/CompositeViewer>
 #include <osgViewer/GraphicsWindow>
@@ -45,12 +45,12 @@ public:
 
     static Window * fromWindow(QQuickWindow *window);
 
-signals:
+Q_SIGNALS:
     void textureInUse();
     void acceptNewSize(osgViewer::ViewQtQuick::Index *view, QSize size);
     void pendingNewTexture();
 
-public slots:
+public Q_SLOTS:
     void frame();
     void ready(); // Context ready for rendering
     void prepareNodes();


### PR DESCRIPTION
1) Not specifying the Qt module names when including Qt headers causes errors on some systems.
2) Also, some systems do not support "signals" and "slots" keywords due to interference with boost.
3) Directories were not being created before generating include files. This causes cmake configure error on Linux-like platforms.
4) Wrong variable name was used in a non-windows section of code. Probably not found because the library wasn't tested on linux.