### PR TITLE
BUGFIX: Setting a camera in the view makes the view blank.

### DIFF
--- a/src/quick/osgviewer/view.cpp
+++ b/src/quick/osgviewer/view.cpp
@@ -105,6 +105,8 @@ osg::CameraQtQml *ViewQtQuick::Index::getCamera()
 void ViewQtQuick::Index::setCamera(osg::CameraQtQml *camera)
 {
     o(this)->setCamera(camera->camera());
+    o(this)->getCamera()->setPreDrawCallback(preDraw.get());
+    o(this)->getCamera()->setPostDrawCallback(postDraw.get());
 }
 
 osgGA::CameraManipulatorQtQml *ViewQtQuick::Index::getCameraManipulator()


### PR DESCRIPTION
This is a partial fix for #14 . Now I can get the rendering if I set the scene data later, but the rendering is still weird. This might give some hints to fix it further.